### PR TITLE
Fix GateWayIntent Class Not Found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 				<configuration>
 				    <transformers>
 					<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-					    <mainClass>YourMainClass</mainClass> <!-- You have to replace this with a path to your main class like my.path.Main -->
+					    <mainClass>fr.maxlego08.discord.ZDiscordPlugin</mainClass>
 					</transformer>
 				    </transformers>
 				    <createDependencyReducedPom>false</createDependencyReducedPom>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,26 @@
 					</descriptorRefs>
 				</configuration>
 			</plugin>
+			<plugin>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.2.1</version>
+				<configuration>
+				    <transformers>
+					<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+					    <mainClass>YourMainClass</mainClass> <!-- You have to replace this with a path to your main class like my.path.Main -->
+					</transformer>
+				    </transformers>
+				    <createDependencyReducedPom>false</createDependencyReducedPom>
+				</configuration>
+				<executions>
+				    <execution>
+					<phase>package</phase>
+					    <goals>
+						<goal>shade</goal>
+					    </goals>
+				    </execution>
+                		</executions>
+            		</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
It appears that in JDA repo that require the presence of shade plugin in pom.xml to correctly include the JDA dependency. Submitting this pull request to fix that issue.